### PR TITLE
add git tar file to installed package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include *.in
 include *.lock
 include LICENSE
 include Pipfile
-recursive-include vendor *.tar
+include git/vendor/*.tar

--- a/git/__init__.py
+++ b/git/__init__.py
@@ -8,7 +8,7 @@ from .logging import LOGGER
 
 
 PKG_PATH = os.path.dirname(os.path.realpath(__file__))
-VENDOR_PATH = os.path.realpath('{}/../vendor'.format(PKG_PATH))
+VENDOR_PATH = os.path.realpath('{}/vendor'.format(PKG_PATH))
 GIT_VERSION = '2.4.3'
 GIT_TAR_FILE = '{}/git-{}.tar'.format(VENDOR_PATH, GIT_VERSION)
 TMP_PATH = '/tmp'

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ about = {}
 exec(get_file_content(os.path.join(ROOT, 'git', '__version__.py')), about)
 
 
+#    package_data={'': ['*.tar']},
 setuptools.setup(
     name=about['__title__'],
     version=about['__version__'],
@@ -25,6 +26,7 @@ setuptools.setup(
     author_email=about['__author_email__'],
     url=about['__url__'],
     packages=setuptools.find_packages(),
+    include_package_data=True,
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Closes https://github.com/eredi93/lambda-git/issues/12

I moved the vendor directory within the package and included the package data.

Thanks @arsalazarjr for the pointer. I use this with Apex and and call `pip install -r requirements.txt -t .` as a build hook which stores all packages in the local directory. this issue was happening only if you install the single package with pip and it doesn't copy the vendor dir in `site-packages`